### PR TITLE
Change "Get more" button's name (setUpMfa to getMore).

### DIFF
--- a/themes/material/mfa/low-on-backup-codes.php
+++ b/themes/material/mfa/low-on-backup-codes.php
@@ -40,7 +40,7 @@
 
                     <span flex></span>
 
-                    <button name="setUpMfa" class="mdl-button mdl-button--raised mdl-button--primary">
+                    <button name="getMore" class="mdl-button mdl-button--raised mdl-button--primary">
                         <?= $this->t('{material:mfa:button_get_more}') ?>
                     </button>
                 </div>

--- a/themes/material/mfa/out-of-backup-codes.php
+++ b/themes/material/mfa/out-of-backup-codes.php
@@ -46,7 +46,7 @@
 
                     <span flex></span>
 
-                    <button name="setUpMfa" class="mdl-button mdl-button--raised mdl-button--primary">
+                    <button name="getMore" class="mdl-button mdl-button--raised mdl-button--primary">
                         <?= $this->t('{material:mfa:button_get_more}') ?>
                     </button>
                 </div>


### PR DESCRIPTION
This is to reflect [the change in design in the MFA Module](https://github.com/silinternational/simplesamlphp-module-mfa/pull/16), where getting more backup codes will happen entirely within the MFA Module (rather than sending the user off to the MFA_SETUP_URL).