### PR TITLE
simplesamlphp 1.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": ">=5.4",
     "roave/security-advisories": "dev-master",
     "simplesamlphp/composer-module-installer": "^1.1.5",
-    "simplesamlphp/simplesamlphp": "^1.14.10",
+    "simplesamlphp/simplesamlphp": "^1.15.2",
     "silinternational/ssp-utilities": "^1.0"
   }
 }

--- a/themes/material/common-head-elements.php
+++ b/themes/material/common-head-elements.php
@@ -3,7 +3,7 @@
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<base href="<?= SimpleSAML_Module::getModuleURL('material/') ?>">
+<base href="<?= SimpleSAML\Module::getModuleURL('material/') ?>">
 
 <?php
 $trackingId = htmlentities($this->configuration->getValue('analytics.trackingId'));


### PR DESCRIPTION
The primary goal is to reduce logged warnings about using the old version of class names (before SimpleSAMLphp classes were namespaced).

I went ahead and updated the composer.json requirements so that this will only install when simplesamlphp 1.15 (or a later backwards-compatible version) is available. I'm therefore considering this a bugfix-level change.