### PR TITLE
bugfix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       PASSWORD_FORGOT_URL:  "https://example.org/forgot"
 
   idp4:  # used for mfa testing (as well as some helpful links)
-    image: silintl/ssp-base:local-testing-with-develop-deps
+    image: silintl/ssp-base:develop
     volumes:
       - ./development/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
       - ./development/idp4/authsources.php:/data/vendor/simplesamlphp/simplesamlphp/config/authsources.php

--- a/themes/material/profilereview/review.php
+++ b/themes/material/profilereview/review.php
@@ -61,7 +61,7 @@
                                     <?= htmlentities($mfa['label']) ?> 
                                     
                                     <?php if ($mfa['type'] == 'backupcode'): ?>
-                                    <?= $this->t('{material:review:remaining}', ['{count}' => $mfa['data']['count']]) ?>
+                                    <?= $this->t('{material:review:remaining}', ['{count}' => (string) $mfa['data']['count']]) ?>
                                     <?php endif; ?>
                                     
                                     <span class="mdl-list__item-text-body">


### PR DESCRIPTION
A translation was broken when the user had `0` remaining codes due to some parameter type requirements.