### PR TITLE
Prevent re-submissions of the login form

### DIFF
--- a/themes/material/core/loginuserpass.php
+++ b/themes/material/core/loginuserpass.php
@@ -44,7 +44,7 @@
     <main class="mdl-layout__content" layout-children="column" child-spacing="center">
         <?php include __DIR__ . '/../common-announcement.php' ?>
 
-        <form method="post" autocomplete="off">
+        <form method="post" autocomplete="off" onsubmit="event.target.onsubmit = event => event.preventDefault()">
             <input type="hidden" name="AuthState" value="<?= htmlentities($this->data['stateparams']['AuthState']) ?>" />
 
             <?php


### PR DESCRIPTION
Multiple submissions can confuse things enough that the user ends up at the Hub login page, unable to get to their destination.

This change simply prevents all form submissions after the first one (until the page reloads).