### PR TITLE
Only add the CSRF token to the login form if one was provided

### DIFF
--- a/themes/material/core/loginuserpass.php
+++ b/themes/material/core/loginuserpass.php
@@ -54,9 +54,13 @@
             <input type="hidden" name="AuthState" value="<?= htmlentities($this->data['stateparams']['AuthState']) ?>" />
 
             <?php
-            $csrfToken = htmlentities($this->data['csrfToken']);
+            if (key_exists('csrfToken', $this->data)) {
+                $csrfToken = htmlentities($this->data['csrfToken']);
+                ?>
+                <input type="hidden" name="csrf-token" value="<?= $csrfToken ?>" />
+                <?php
+            }
             ?>
-            <input type="hidden" name="csrf-token" value="<?= $csrfToken ?>" />
 
             <div class="mdl-card mdl-shadow--8dp fill-phone-viewport">
                 <div class="mdl-card__media white-bg margin" layout-children="column">


### PR DESCRIPTION
### Fixed
- Only add the CSRF token to the login form if one was provided

---

This may only happen when using this theme without using our silauth module, but it was one of the errors I saw in the log that was easy to fix.