### PR TITLE
Update spanish translations on two strings.

### DIFF
--- a/dictionaries/mfa.definition.json
+++ b/dictionaries/mfa.definition.json
@@ -133,13 +133,13 @@
 	},
 	"webauthn_error_abort": {
 		"en": "It looks like you clicked cancel. Would you like us to try again?",
-		"es": "It looks like you clicked cancel. Would you like us to try again?",
+		"es": "Parece que has hecho clic en cancelar. ¿Quieres que lo intentemos de nuevo?",
 		"fr": "Il semble que vous ayez cliqué sur annuler. Souhaitez-vous que nous essayions à nouveau ?",
 		"ko": "It looks like you clicked cancel. Would you like us to try again?"
 	},
 	"webauthn_error_not_allowed": {
 		"en": "Something about that didn't work. Please ensure that your security key is plugged in and that you touch it within 60 seconds when it blinks.",
-		"es": "Something about that didn't work. Please ensure that your security key is plugged in and that you touch it within 60 seconds when it blinks.",
+		"es": "Algo de eso no funcionó. Por favor, asegúrese de que su clave de seguridad está conectada y de que la toca en un plazo de 60 segundos cuando parpadea.",
 		"fr": "Quelque chose n'a pas fonctionné avec ça. Veuillez vous assurer que votre clé de sécurité est insérée et que vous la touchez dans les 60 secondes lorsqu'elle clignote.",
 		"ko": "Something about that didn't work. Please ensure that your security key is plugged in and that you touch it within 60 seconds when it blinks."
 	},


### PR DESCRIPTION
This is for https://trello.com/c/2xde8wa2/315-put-korean-and-spanish-translations-in-place-for-new-webauthn-text-in-the-idps.  My understanding is that Scott wants us to use Crowdin suggested translations where possible (avoiding Google verbatim translations) and leave the Korean as English where we don't have a translation otherwise.