### PR TITLE
Add width related styling to the header in order to allow the word wrap to styling to function

### DIFF
--- a/themes/material/default/selectidp-links.php
+++ b/themes/material/default/selectidp-links.php
@@ -28,7 +28,7 @@
 <div class="mdl-layout mdl-layout--fixed-header fill-viewport">
     <header class="mdl-layout__header">
         <div class="mdl-layout__header-row">
-            <span class="mdl-layout-title">
+            <span class="mdl-layout-title scale-to-parent">
             <?php
             $spName = $this->data['spName'] ?? null;
             if (empty($spName)) {


### PR DESCRIPTION
You can test this by adding the `scale-to-parent` style to the header element in the dev tools on one of the hub's IdP discovery page.

For me the `overflow` type styling didn't make an wrapping happen, unless I also added a `width` type style.